### PR TITLE
Added symlinks for Busybox utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,9 @@
 # http://github.com/jhowardmsft/busybox
 
 FROM windowsservercore
-ADD http://frippery.org/files/busybox/busybox.exe /
-ENTRYPOINT ["/busybox.exe"]
+RUN mkdir C:\busybox
+ADD http://frippery.org/files/busybox/busybox.exe /busybox/
+ADD alias.ps1 /busybox/
+RUN setx /M PATH "C:\busybox;%PATH%"
+RUN powershell C:/busybox/alias.ps1
+ENTRYPOINT ["C:/busybox/busybox.exe"]

--- a/alias.ps1
+++ b/alias.ps1
@@ -1,0 +1,6 @@
+﻿$commands = busybox.exe --list
+
+ForEach($command in $commands) {
+    $commandexe = "C:\busybox\$command.exe"
+    $nul = cmd /c mklink $commandexe busybox.exe
+}


### PR DESCRIPTION
This adds symlinks to the busybox image for Windows. It makes the use of busybox in Dockerfile contexts work on Windows.
