### PR TITLE
fix: update the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@
 #
 # http://github.com/jhowardmsft/busybox
 
-FROM microsoft/windowsservercore
-RUN mkdir C:\tmp && mkdir C:\bin
-ADD http://frippery.org/files/busybox/busybox.exe /bin/
-RUN setx /M PATH "C:\bin;%PATH%"
-RUN powershell busybox.exe --list ^|%{$nul = cmd /c mklink C:\bin\$_.exe busybox.exe}
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+# combining the RUN steps to reduce the layer size
+RUN mkdir C:\tmp && mkdir C:\bin \
+    && curl -fsSLO http://frippery.org/files/busybox/busybox.exe \
+    && setx /M PATH "C:\bin;%PATH%" \
+    && powershell C:\busybox.exe --list ^|%{$nul = cmd /c mklink C:\bin\$_.exe C:\busybox.exe}
 CMD ["sh"]


### PR DESCRIPTION
This PR fixes the dockerfile is outdated since
the Windows images are now hosted at MCR.

Also ADD stanza gives back a 403 error from frippery.org, could be HTTP header issues, switched it to curl instead.
```
Step 3/6 : ADD http://frippery.org/files/busybox/busybox.exe /bin/
ADD failed: failed to GET http://frippery.org/files/busybox/busybox.exe with status 403 Forbidden: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>403 Forbidden</title>
</head><body>
<h1>Forbidden</h1>
<p>You don't have permission to access this resource.</p>
<hr>
<address>Apache/2.4.38 (Debian) Server at frippery.org Port 80</address>
</body></html>
```

### After the fix

```
docker build --no-cache -t busybox .
Sending build context to Docker daemon  2.048kB
Step 1/6 : FROM mcr.microsoft.com/windows/servercore:ltsc2022
 ---> 1fb25eb608ab
Step 2/6 : RUN mkdir C:\tmp && mkdir C:\bin
 ---> Running in 5958d3f1aa08
 ---> Removed intermediate container 5958d3f1aa08
 ---> d57c51d0a834
Step 3/6 : RUN curl -LO http://frippery.org/files/busybox/busybox.exe
 ---> Running in dbd2517e9092
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  600k  100  600k    0     0   251k      0  0:00:02  0:00:02 --:--:--  251k
 ---> Removed intermediate container dbd2517e9092
 ---> ecccce5b0c82
Step 4/6 : RUN setx /M PATH "C:\bin;%PATH%"
 ---> Running in c218fcb23a8c

SUCCESS: Specified value was saved.
 ---> Removed intermediate container c218fcb23a8c
 ---> 22e4766d1427
Step 5/6 : RUN powershell C:\busybox.exe --list ^|%{$nul = cmd /c mklink C:\bin\$_.exe C:\busybox.exe}
 ---> Running in 55bffed6155c
 ---> Removed intermediate container 55bffed6155c
 ---> 7b4c43d1f3a0
Step 6/6 : CMD ["sh"]
 ---> Running in 1bc9699751a6
 ---> Removed intermediate container 1bc9699751a6
 ---> 8463fa32fa3a
Successfully built 8463fa32fa3a
Successfully tagged busybox:latest
```
**`docker run -it busybox cmd`**:
![image](https://github.com/moby/busybox/assets/261265/0739f37d-90da-4974-9b73-9be94960d770)

